### PR TITLE
Allow contentscript.js to run on all child frames

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -158,7 +158,7 @@
                 "scripts/contentscript.js"
             ],
             "run_at": "document_end",
-            "all_frames": false
+            "all_frames": true
         }
     ],
     "permissions": [


### PR DESCRIPTION
Support use in ~~shitty~~ frame-based CMS's (eg: Squiz Matrix / Blackboard 9.x)

Note: chrome will still only run contentscript.js in frames that exist when run (`document_end`) - not in any that are dynamically loaded, so some third-party plugins that use textareas might miss out.